### PR TITLE
Add .arg to misc postfix templates

### DIFF
--- a/misc.postfixTemplates
+++ b/misc.postfixTemplates
@@ -1,5 +1,8 @@
 ## others ##
 
+.arg : wrap expression in function call
+	ANY        →  $function$($expr$)$end$
+
 .wrap : wrap err
 	ERROR      →  errors.Wrap($expr$, "$end$")
 	


### PR DESCRIPTION
The `.arg` template is provided by JetBrains in JavaScript but not in Go, so here is my suggestion to add it.